### PR TITLE
debounce the input field, rather than the computed list

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -2,13 +2,19 @@ import Ember from 'ember';
 
 export default Ember.ArrayController.extend({
   searchTerm: "",
-  filteredList: Ember.computed("content.@each", "searchTerm", function() {
+  setDebouncedSearchTerm: function() {
+    this.set("debouncedSearchTerm", this.get("searchTerm"));
+  },
+  observeSearchTerm: Ember.observer("searchTerm", function() {
+    Ember.run.debounce(this, this.setDebouncedSearchTerm, 250);
+  }),
+  filteredList: Ember.computed("content.@each", "debouncedSearchTerm", function() {
 	var _this = this;
 	var filter = function() {
 	  return this.get("content").filter(function(item) {
-		if(!_this.get("searchTerm")) { return false; }
+		if(!_this.get("debouncedSearchTerm")) { return false; }
 
-		return item.get("Title").toLowerCase().indexOf(_this.get("searchTerm").toLowerCase()) > -1;
+		return item.get("Title").toLowerCase().indexOf(_this.get("debouncedSearchTerm").toLowerCase()) > -1;
 	  });
 	};
 


### PR DESCRIPTION
Trying to debounce in a computed property is tricky since `Ember.run.debounce` doesn't return the return value of the debounced function, it has its own return value, meaning a debounced function can only be used for its side effects. 

It's weird, and ugly/tricky enough to make me wonder if there's a better pattern out there. That said, the workaround is to debounce the input, and observe the debounced input in the computed property, which seems to work.
